### PR TITLE
Cleanup: no need to deactivate l7proxy when activating EgressGetway

### DIFF
--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -97,8 +97,7 @@ The egress gateway feature and all the requirements can be enabled as follow:
                --reuse-values \\
                --set egressGateway.enabled=true \\
                --set bpf.masquerade=true \\
-               --set kubeProxyReplacement=true \\
-               --set l7Proxy=false
+               --set kubeProxyReplacement=true
 
     .. group-tab:: ConfigMap
 


### PR DESCRIPTION
Cleaning up a minor oversight in the documentation following this merge https://github.com/cilium/cilium/pull/32828 - and this comment: https://github.com/cilium/cilium/pull/32828/#issuecomment-2180931026
